### PR TITLE
添加 MoonProxy — 跨平台 FRP 桌面客户端（GUI）到内网穿透工具列表

### DIFF
--- a/README.md
+++ b/README.md
@@ -908,6 +908,7 @@ Captive Portal 功能常见于商用和企业级设备，家用路由器支持�
 - 同时支持 NAT 打洞和服务器中转的内网穿透工具
   - [ZeroTier](https://www.zerotier.com/): 主打 NAT 打洞，NAT 打洞成功率较高。打洞失败后回退到服务器中转。
   - [frp](https://github.com/fatedier/frp): 支持多种协议的内网穿透工具
+  - [MoonProxy](https://github.com/MoonProxyHQ/moonproxy-desktop): 跨平台 FRP 桌面客户端（GUI），让非技术用户也能使用 frp 进行内网穿透
   - [nps](https://github.com/ehang-io/nps): 支持多种协议的内网穿透工具
   - [花生壳](https://hsk.oray.com/): 商业服务，包含 DDNS 和内网穿透，操作简单
   - [Tailscale](https://tailscale.com): 与 ZeroTier 类似，基于 WireGuard®


### PR DESCRIPTION
在「内网穿透」章节的 frp 条目下方，添加 **MoonProxy**。

## 关于 MoonProxy

[MoonProxy](https://github.com/MoonProxyHQ/moonproxy-desktop)（月神代理）是基于 **Tauri v2 + Vue 3 + Rust + TypeScript** 构建的跨平台 **frpc 图形界面桌面客户端**。它通过图形化界面暴露本地 TCP/UDP/HTTP/HTTPS 服务 —— 无需命令行，无需手写配置文件。MIT 开源，支持 **macOS（Apple Silicon + Intel）与 Windows**。

## 为什么适合收录

- **直接相关**：MoonProxy 是 frp 的桌面 GUI 客户端，本质上降低了 frp 的使用门槛，与本仓库「家庭网络知识整理」主题中的「内网穿透」章节高度契合。
- **降低门槛**：非技术用户（家庭用户）也能借助图形界面完成内网穿透配置，正好补足了本章节目前只列出 frp 等命令行工具、缺乏易用入口的空白。
- **活跃维护**：持续提交、中文文档友好、MIT 协议。
- **独立性**：MoonProxy 不修改 frpc 行为，只负责生成配置、管理子进程生命周期、可视化连接状态。

## 链接

- 仓库：https://github.com/MoonProxyHQ/moonproxy-desktop
- 官网：https://moonproxy.app
- 协议：MIT
- 最新发布：https://github.com/MoonProxyHQ/moonproxy-desktop/releases/latest

如位置或措辞需要调整，欢迎告知，谢谢！